### PR TITLE
Improve error when a request from a test cannot be routed to the component

### DIFF
--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -54,7 +54,13 @@ impl Guest for Component {
             bindings::set_component_id(component_id);
             downstream(request, response_out)
         } else {
-            ResponseOutparam::set(response_out, Err(ErrorCode::InternalError(None)))
+            ResponseOutparam::set(
+                response_out,
+                Err(ErrorCode::InternalError(
+                    format!("no route found in spin.toml manifest for request path '{path}'")
+                        .into(),
+                )),
+            )
         }
     }
 }

--- a/examples/test-rs/.gitignore
+++ b/examples/test-rs/.gitignore
@@ -1,0 +1,1 @@
+test.wasm


### PR DESCRIPTION
One might be tempted to return a 404 instead of erroring like this, but I believe the error is the right approach as it is a direct signal that the app under test was not even reached. 