### PR TITLE
Build in a very basic "tool.spin-test" config

### DIFF
--- a/examples/apps/app-py/spin.toml
+++ b/examples/apps/app-py/spin.toml
@@ -17,3 +17,7 @@ key_value_stores = ["cache"]
 [component.my-app.build]
 command = "componentize-py -w spin-http componentize app -o app.wasm"
 watch = ["app.py", "Pipfile"]
+[component.my-app.tool.spin-test]
+source = "../../test-rs/target/wasm32-wasi/release/wasm_test.wasm"
+build = "cargo component build --release --target-dir=target"
+dir = "../../test-rs"

--- a/examples/apps/app-rs/spin.toml
+++ b/examples/apps/app-rs/spin.toml
@@ -23,3 +23,7 @@ command = "cargo build --target wasm32-wasi --release"
 watch = ["src/**/*.rs", "Cargo.toml"]
 [component.my-app.variables]
 cache_name = "cache"
+[component.my-app.tool.spin-test]
+source = "../../test-rs/target/wasm32-wasi/release/wasm_test.wasm"
+build = "cargo component build --release --target-dir=target"
+dir = "../../test-rs"

--- a/examples/test-rs/.gitignore
+++ b/examples/test-rs/.gitignore
@@ -1,1 +1,2 @@
 test.wasm
+target/


### PR DESCRIPTION
This allows specifying in the Spin.toml where the test lives and how to build it. `spin-test` will automatically find and build the test before running it. `spin-test` now no longer needs to be called with any arguments. 

This does place a limit on only one test component per app component. This is probably fine for now, but we might want to adjust this soon.