### PR TITLE
Wrap the encoded bytes in an Arc to prevent large copies

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,7 @@ fn run_tests(
     encoded: Vec<u8>,
 ) -> anyhow::Result<Vec<libtest_mimic::Trial>> {
     let mut trials = vec![];
+    let encoded = std::sync::Arc::new(encoded);
 
     match test_target {
         spin_test::TestTarget::AdHoc { exports } => {


### PR DESCRIPTION
Encoded bytes could be fairly large, so let's reduce the amount of memory we need by wrapping everything in an `Arc`.