### PR TITLE
add plugnify to enable local plugin installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+test-*.tar.gz
+test.json

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ This will install the plugin which can be invoked with `spin test`.
 
 In the future, stable, non-canary releases will also be made available.
 
+#### Installing a Locally Built Version
+
+To install a version of `spin-test` plugin that has been locally built using `cargo build --release`, use the following command:
+
+```bash
+spin pluginify -i
+```
+
+Note: the [`pluginify`](https://github.com/fermyon/spin-plugins/blob/main/manifests/pluginify/pluginify.json) plugin is a pre-requisite.
+
 ### Install `spin-test` (stand alone)
 
 Alternatively, to install `spin-test` as a stand alone binary, run `cargo build --release` from this directory and ensure that the resulting binary is located on your path.

--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,0 +1,5 @@
+name = "test"
+version = "0.1"
+spin_compatibility = ">=2.0"
+license = "Apache-2.0"
+package = "./target/release/spin-test"


### PR DESCRIPTION
I find having the ability to build and install plugins locally helpful instead of having to directly invoke the binary. The workflow with this PR will be the following when changes are to be tested.

```bash
cargo build --release && spin pluginify -i
spin test <rest of the command>
```