### PR TITLE
404 when router cannot find component to route to

### DIFF
--- a/crates/spin-test-virt/src/wasi/http.rs
+++ b/crates/spin-test-virt/src/wasi/http.rs
@@ -84,6 +84,12 @@ impl<T: Clone> Consumable<T> {
     }
 }
 
+impl<T> From<T> for Consumable<T> {
+    fn from(value: T) -> Self {
+        Consumable::new(value)
+    }
+}
+
 impl exports::types::GuestIncomingRequest for IncomingRequest {
     fn method(&self) -> exports::types::Method {
         self.method.clone()
@@ -256,7 +262,17 @@ impl exports::types::GuestOutgoingBody for OutgoingBody {
 }
 
 #[derive(Clone)]
-pub struct IncomingBody(pub io::Buffer);
+pub struct IncomingBody(io::Buffer);
+
+impl IncomingBody {
+    pub fn new(buffer: io::Buffer) -> Self {
+        Self(buffer)
+    }
+
+    pub fn empty() -> Self {
+        Self::new(io::Buffer::empty())
+    }
+}
 
 impl exports::types::GuestIncomingBody for IncomingBody {
     fn stream(&self) -> Result<io::exports::streams::InputStream, ()> {
@@ -273,6 +289,15 @@ impl exports::types::GuestIncomingBody for IncomingBody {
 impl From<OutgoingBody> for IncomingBody {
     fn from(o: OutgoingBody) -> Self {
         Self(o.0)
+    }
+}
+
+impl<T> From<T> for IncomingBody
+where
+    T: Into<io::Buffer>,
+{
+    fn from(t: T) -> Self {
+        Self(t.into())
     }
 }
 

--- a/crates/spin-test-virt/src/wasi/http_helper.rs
+++ b/crates/spin-test-virt/src/wasi/http_helper.rs
@@ -3,14 +3,13 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::Component;
-
 use crate::bindings::exports::fermyon::spin_wasi_virt::http_helper as exports;
+use crate::Component;
 
 use super::{
     http::{
-        Fields, IncomingBody, IncomingRequest, IncomingResponse, OutgoingRequest, OutgoingResponse,
-        ResponseOutparam,
+        self, Fields, IncomingBody, IncomingRequest, IncomingResponse, OutgoingRequest,
+        OutgoingResponse, ResponseOutparam,
     },
     io,
 };
@@ -35,9 +34,7 @@ impl exports::Guest for Component {
             authority,
             path_with_query,
             headers,
-            body: super::http::Consumable::new(
-                body.unwrap_or_else(|| IncomingBody(io::Buffer::empty())),
-            ),
+            body: body.unwrap_or_else(IncomingBody::empty).into(),
         })
     }
 
@@ -65,16 +62,36 @@ pub struct ResponseReceiver(
 
 impl exports::GuestResponseReceiver for ResponseReceiver {
     fn get(&self) -> Option<exports::IncomingResponse> {
-        match &*self.0.lock().unwrap() {
+        let response = match &*self.0.lock().unwrap() {
             Some(Ok(r)) => {
                 let outgoing = r.get::<OutgoingResponse>();
-                Some(exports::IncomingResponse::new(IncomingResponse {
+                Some(IncomingResponse {
                     status: outgoing.status_code.get(),
                     headers: outgoing.headers.clone(),
                     body: outgoing.body.unconsume().map(Into::into),
-                }))
+                })
             }
-            Some(Err(_)) | None => None,
-        }
+            Some(Err(e)) => {
+                use http::exports::types::ErrorCode;
+                let (status, msg) = match &e {
+                    ErrorCode::InternalError(Some(msg)) => (500, msg.clone()),
+                    ErrorCode::InternalError(None) => {
+                        (500, "an internal error occurred".to_owned())
+                    }
+                    ErrorCode::DestinationNotFound => (
+                        404,
+                        "no route found in spin.toml manifest for request path".to_owned(),
+                    ),
+                    _ => (500, e.to_string()),
+                };
+                Some(IncomingResponse {
+                    status,
+                    headers: Fields::default(),
+                    body: IncomingBody::new(msg.into()).into(),
+                })
+            }
+            None => None,
+        };
+        response.map(exports::IncomingResponse::new)
     }
 }

--- a/crates/spin-test-virt/src/wasi/io.rs
+++ b/crates/spin-test-virt/src/wasi/io.rs
@@ -284,3 +284,9 @@ impl From<Vec<u8>> for Buffer {
         Buffer::new(v)
     }
 }
+
+impl From<String> for Buffer {
+    fn from(v: String) -> Self {
+        Buffer::new(v.into_bytes())
+    }
+}


### PR DESCRIPTION
Fixes #67 

The router know returns a `ErrorCode::DestinationNotFound` when it cannot route to the component, and the `spin_test_virt` translates that into a 404 with the appropriate message. 