### PR TITLE
Make sure destination file mounts are at path relative to manifest

### DIFF
--- a/crates/spin-test-virt/src/wasi/filesystem.rs
+++ b/crates/spin-test-virt/src/wasi/filesystem.rs
@@ -308,7 +308,6 @@ impl crate::bindings::exports::fermyon::spin_wasi_virt::fs_handler::Guest for Co
 }
 
 struct FileSystem;
-static FILES: OnceLock<Mutex<HashMap<String, Arc<Vec<u8>>>>> = OnceLock::new();
 
 impl FileSystem {
     fn add(path: String, contents: Vec<u8>) {
@@ -322,6 +321,7 @@ impl FileSystem {
     }
 
     fn get_files() -> std::sync::MutexGuard<'static, HashMap<String, Arc<Vec<u8>>>> {
+        static FILES: OnceLock<Mutex<HashMap<String, Arc<Vec<u8>>>>> = OnceLock::new();
         FILES
             .get_or_init(|| Mutex::new(HashMap::new()))
             .lock()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -166,16 +166,14 @@ impl Runtime {
                             }
                             // Guest path is the path relative to the manifest appended to the destination
                             let guest_path = std::path::Path::new(&destination)
-                                // Unwrap should be fine since we know this is a file
-                                .join(host_path.file_name().unwrap());
+                                .join(self.manifest.relative_from(&host_path));
 
                             add_file(&mut self.store, &runner, &host_path, &guest_path)?;
                         }
                     } else {
                         // Guest path is the path relative to the manifest appended to the destination
                         let guest_path = std::path::Path::new(&destination)
-                            // Unwrap should be fine since we know this is a file
-                            .join(host_path.file_name().unwrap());
+                            .join(self.manifest.relative_from(&host_path));
                         add_file(&mut self.store, &runner, &host_path, &guest_path)?
                     }
                 }


### PR DESCRIPTION
Otherwise, we only end up with all files being flatten to the top level directory. 