### PR TITLE
Exit with 101 on test failure

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,9 +82,7 @@ impl Run {
         .context("failed to compose Spin app, test, and virtualized Spin environment")?;
 
         let tests = run_tests(&test_name, test_target, encoded, manifest)?;
-        let _ = libtest_mimic::run(&libtest_mimic::Arguments::default(), tests);
-
-        Ok(())
+        libtest_mimic::run(&libtest_mimic::Arguments::default(), tests).exit();
     }
 }
 


### PR DESCRIPTION
Currently we always exit with 0 whether the tests pass or not. 