### PR TITLE
check exit code after running build command

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use anyhow::anyhow;
 use anyhow::Context as _;
 
 #[derive(Clone)]
@@ -136,9 +137,15 @@ impl BuildInfo {
         if let Some(workdir) = self.workdir {
             cmd.current_dir(workdir);
         }
-        cmd.args(["-c", &self.cmd])
+        let status = cmd
+            .args(["-c", &self.cmd])
             .status()
-            .context("failed to build component")?;
-        Ok(())
+            .context("failed to run test component build command")?;
+
+        if status.success() {
+            return Ok(());
+        }
+
+        Err(anyhow!("failed to build test component. {}", status))
     }
 }


### PR DESCRIPTION
fixes #90 

before the fix:

```

Error: Failed to initialize the compiled Wasm binary with Wizer:
Wizering failed to complete
    at componentize (file:///Users/rajatjindal/go/src/github.com/rajatjindal/test-api/node_modules/@bytecodealliance/componentize-js/src/componentize.js:217:11)
    at async file:///Users/rajatjindal/go/src/github.com/rajatjindal/test-api/server/tests/componentize.mjs:6:23

error: failed to read test component 'test.wasm'

```
after the fix:

```
Error: Failed to initialize the compiled Wasm binary with Wizer:
Wizering failed to complete
    at componentize (file:///Users/rajatjindal/go/src/github.com/rajatjindal/test-api/node_modules/@bytecodealliance/componentize-js/src/componentize.js:217:11)
    at async file:///Users/rajatjindal/go/src/github.com/rajatjindal/test-api/server/tests/componentize.mjs:6:23

error: failed to build test component. exit status: 1
```