### PR TITLE
Add binary app for running conformance tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +359,29 @@ name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "conformance-tests"
+version = "0.1.0"
+source = "git+https://github.com/fermyon/conformance-tests#24f4d8cbde6c7e3859d2987382fe4f552f5f1c75"
+dependencies = [
+ "anyhow",
+ "flate2",
+ "json5",
+ "reqwest",
+ "serde",
+ "tar",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -685,16 +720,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -820,7 +892,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "debugid",
  "fxhash",
  "serde",
@@ -1012,6 +1084,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1279,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1194,7 +1319,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "libc",
 ]
 
@@ -1262,6 +1387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1421,24 @@ dependencies = [
  "serde_json",
  "serde_qs",
  "spin-sdk",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1328,6 +1477,50 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ouroboros"
@@ -1376,6 +1569,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1621,26 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.2.6",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -1511,6 +1769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,6 +1831,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
+name = "reqwest"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "routefinder"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,7 +1891,7 @@ dependencies = [
  "spin-http",
  "spin-manifest",
  "toml",
- "wit-bindgen-rt",
+ "wit-bindgen-rt 0.26.0",
 ]
 
 [[package]]
@@ -1602,7 +1912,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "errno",
  "itoa",
  "libc",
@@ -1610,6 +1920,22 @@ dependencies = [
  "once_cell",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustversion"
@@ -1622,6 +1948,38 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1680,6 +2038,18 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -1917,7 +2287,7 @@ name = "spin-serde"
 version = "2.6.0-pre0"
 source = "git+https://github.com/fermyon/spin#424bff5c5949ca71e73f69cb551d4104c71504a8"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "serde",
 ]
 
@@ -1946,6 +2316,17 @@ dependencies = [
  "wasmtime-wasi",
  "wit-component 0.208.1",
  "wit-parser 0.208.1",
+]
+
+[[package]]
+name = "spin-test-conformance-tests"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "conformance-tests",
+ "spin-test",
+ "wasmtime",
+ "wasmtime-wasi",
 ]
 
 [[package]]
@@ -1978,7 +2359,7 @@ dependencies = [
  "spin-outbound-networking",
  "spin-serde",
  "toml",
- "wit-bindgen-rt",
+ "wit-bindgen-rt 0.25.0",
 ]
 
 [[package]]
@@ -2038,12 +2419,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-interface"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b858526d22750088a9b3cf2e3c2aacebd5377f13adeec02860c30d09113010a6"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
@@ -2051,6 +2459,17 @@ dependencies = [
  "rustix",
  "windows-sys 0.52.0",
  "winx",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2157,6 +2576,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2205,6 +2634,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2247,6 +2704,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-bidi"
@@ -2315,6 +2778,12 @@ name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2393,6 +2862,18 @@ dependencies = [
  "quote",
  "syn 2.0.63",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2565,7 +3046,7 @@ version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "indexmap 2.2.6",
  "semver",
 ]
@@ -2576,7 +3057,7 @@ version = "0.200.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a03f65ac876612140c57ff6c3b8fe4990067cce97c2cfdb07368a3cc3354b062"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "indexmap 2.2.6",
  "semver",
 ]
@@ -2587,7 +3068,7 @@ version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6998515d3cf3f8b980ef7c11b29a9b1017d4cf86b99ae93b546992df9931413"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "indexmap 2.2.6",
  "semver",
 ]
@@ -2599,7 +3080,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19bb9f8ab07616da582ef8adb24c54f1424c7ec876720b7da9db8ec0626c92c"
 dependencies = [
  "ahash",
- "bitflags",
+ "bitflags 2.5.0",
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "semver",
@@ -2612,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd921789c9dcc495f589cb37d200155dee65b4a4beeb853323b5e24e0a5f9c58"
 dependencies = [
  "ahash",
- "bitflags",
+ "bitflags 2.5.0",
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "semver",
@@ -2700,7 +3181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19200760d6720b40da359c096d050056731300d253cd2ed8614e6940c10f766c"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "directories-next",
  "log",
  "postcard",
@@ -2860,7 +3341,7 @@ checksum = "82e7931e19286a853fb5cae7790f9be473f7ab763043c659f1fa0a2a8eada10b"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags",
+ "bitflags 2.5.0",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
@@ -2944,6 +3425,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wiggle"
 version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2951,7 +3442,7 @@ checksum = "f08c5d8fa4a78e3b4617087f38a4e3d2a99f77564fb8cbc081171f51e71be68f"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags",
+ "bitflags 2.5.0",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -3191,12 +3682,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "winx"
 version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9643b83820c0cd246ecabe5fa454dd04ba4fa67996369466d0747472d337346"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3206,7 +3707,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b76f1d099678b4f69402a421e888bbe71bf20320c2f3f3565d0e7484dbe5bc20"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
  "wit-bindgen-rust-macro 0.16.0",
 ]
 
@@ -3216,7 +3717,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f497a5ce965e6cb9929079bb4af633bd88dfb19d0dfc5341580e354947f00b2"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen-rt 0.25.0",
  "wit-bindgen-rust-macro 0.25.0",
 ]
 
@@ -3248,8 +3749,14 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef83e2f948056d4195b4c2a236a10378b70c8fd7501039c5a106c1a756fa7da6"
 dependencies = [
- "bitflags",
+ "bitflags 2.5.0",
 ]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c7526379ace8709ee9ab9f2bb50f112d95581063a59ef3097d9c10153886c9"
 
 [[package]]
 name = "wit-bindgen-rust"
@@ -3314,7 +3821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a35a2a9992898c9d27f1664001860595a4bc99d32dd3599d547412e17d7e2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.5.0",
  "indexmap 2.2.6",
  "log",
  "serde",
@@ -3333,7 +3840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39979723340baea490b87b11b2abae05f149d86f2b55c18d41d78a2a2b284c16"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.5.0",
  "indexmap 2.2.6",
  "log",
  "serde",
@@ -3352,7 +3859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef7dd0e47f5135dd8739ccc5b188ab8b7e27e1d64df668aa36680f0b8646db8"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.5.0",
  "indexmap 2.2.6",
  "log",
  "serde",
@@ -3445,6 +3952,17 @@ dependencies = [
  "log",
  "thiserror",
  "wast 35.0.2",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,12 @@ wit-component = { workspace = true }
 wit-parser = { workspace = true }
 
 [workspace]
-members = ["crates/*", "examples/test-rs", "examples/apps/app-rs"]
+members = [
+    "crates/*",
+    "examples/test-rs",
+    "examples/apps/app-rs",
+    "conformance-tests",
+]
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/conformance-tests/Cargo.toml
+++ b/conformance-tests/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "spin-test-conformance-tests"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+conformance-tests = { git = "https://github.com/fermyon/conformance-tests" }
+spin-test = { path = ".." }
+wasmtime = "21.0"
+wasmtime-wasi = "21.0"

--- a/conformance-tests/src/main.rs
+++ b/conformance-tests/src/main.rs
@@ -1,0 +1,339 @@
+use anyhow::Context as _;
+use bindings::{exports::wasi::http::types::HeaderError, VirtualizedApp};
+
+mod bindings {
+    wasmtime::component::bindgen!({
+        world: "virtualized-app",
+        path: "../host-wit",
+        with: {
+            "wasi:io": wasmtime_wasi::bindings::io,
+            "wasi:clocks": wasmtime_wasi::bindings::clocks,
+        }
+    });
+}
+
+fn main() {
+    let tests_dir = conformance_tests::download_tests().unwrap();
+
+    for test in conformance_tests::tests(&tests_dir).unwrap() {
+        let engine = wasmtime::Engine::default();
+        let manifest = String::from_utf8(std::fs::read(test.manifest).unwrap()).unwrap();
+        let mut store = wasmtime::Store::new(&engine, StoreData::new(manifest));
+        let mut linker = wasmtime::component::Linker::new(&engine);
+        let component = spin_test::Component::from_file(test.component).unwrap();
+        let component = spin_test::virtualize_app(component)
+            .context("failed to virtualize app")
+            .unwrap();
+        let component = wasmtime::component::Component::new(&engine, component).unwrap();
+        wasmtime_wasi::add_to_linker_sync(&mut linker).unwrap();
+        bindings::VirtualizedApp::add_to_linker(&mut linker, |x| x).unwrap();
+
+        let (instance, _) =
+            bindings::VirtualizedApp::instantiate(&mut store, &component, &linker).unwrap();
+        for invocation in test.config.invocations {
+            let conformance_tests::config::Invocation::Http(invocation) = invocation;
+            let fields = Fields::new(&instance, &mut store).unwrap();
+            for header in invocation.request.headers.iter() {
+                fields
+                    .append(&mut store, &header.name, &header.value.clone().into_bytes())
+                    .unwrap()
+                    .unwrap();
+            }
+            let outgoing_request = OutgoingRequest::new(&instance, &mut store, fields).unwrap();
+            outgoing_request
+                .set_path_with_query(&mut store, Some(invocation.request.path.as_str()))
+                .unwrap()
+                .unwrap();
+            let request = IncomingRequest::new(&instance, &mut store, outgoing_request).unwrap();
+            let (out, rx) = new_response(&instance, &mut store).unwrap();
+            instance
+                .wasi_http_incoming_handler()
+                .call_handle(&mut store, request.resource, out)
+                .unwrap();
+            let response = rx.get(&mut store).unwrap().unwrap();
+
+            let status = response.status(&mut store).unwrap();
+            let body = response
+                .consume(&mut store)
+                .unwrap()
+                .unwrap()
+                .stream(&mut store)
+                .unwrap()
+                .unwrap()
+                .blocking_read(&mut store, u64::MAX)
+                .unwrap()
+                .unwrap();
+            let body = String::from_utf8(body).unwrap_or_else(|_| String::from("invalid utf-8"));
+            assert_eq!(
+                status, invocation.response.status,
+                "request to Spin failed\nbody:\n{body}",
+            );
+
+            let mut actual_headers = response
+                .headers(&mut store)
+                .unwrap()
+                .entries(&mut store)
+                .unwrap()
+                .into_iter()
+                .map(|(k, v)| {
+                    (
+                        k.to_lowercase(),
+                        String::from_utf8(v).unwrap().to_lowercase(),
+                    )
+                })
+                .collect::<std::collections::HashMap<_, _>>();
+            for expected_header in invocation.response.headers {
+                let expected_name = expected_header.name.to_lowercase();
+                let expected_value = expected_header.value.map(|v| v.to_lowercase());
+                let actual_value = actual_headers.remove(&expected_name);
+                let Some(actual_value) = actual_value.as_deref() else {
+                    if expected_header.optional {
+                        continue;
+                    } else {
+                        panic!(
+                            "expected header {name} not found in response",
+                            name = expected_header.name
+                        )
+                    }
+                };
+                if let Some(expected_value) = expected_value {
+                    assert_eq!(actual_value, expected_value);
+                }
+            }
+            if !actual_headers.is_empty() {
+                panic!("unexpected headers: {actual_headers:?}");
+            }
+
+            if let Some(expected_body) = invocation.response.body {
+                assert_eq!(body, expected_body);
+            }
+        }
+    }
+}
+
+struct Fields<'a> {
+    guest: bindings::exports::wasi::http::types::GuestFields<'a>,
+    resource: wasmtime::component::ResourceAny,
+}
+
+impl<'a> Fields<'a> {
+    pub fn new<T>(
+        instance: &'a VirtualizedApp,
+        store: &mut wasmtime::Store<T>,
+    ) -> anyhow::Result<Self> {
+        let guest = instance.wasi_http_types().fields();
+        let resource = guest.call_constructor(store)?;
+        Ok(Self { guest, resource })
+    }
+
+    pub fn append<T>(
+        &self,
+        store: &mut wasmtime::Store<T>,
+        name: &String,
+        value: &Vec<u8>,
+    ) -> anyhow::Result<Result<(), HeaderError>> {
+        self.guest.call_append(store, self.resource, name, value)
+    }
+
+    fn entries(
+        &self,
+        store: &mut wasmtime::Store<StoreData>,
+    ) -> wasmtime::Result<Vec<(String, Vec<u8>)>> {
+        self.guest.call_entries(store, self.resource)
+    }
+}
+
+struct OutgoingRequest<'a> {
+    guest: bindings::exports::wasi::http::types::GuestOutgoingRequest<'a>,
+    resource: wasmtime::component::ResourceAny,
+}
+
+impl<'a> OutgoingRequest<'a> {
+    pub fn new<T>(
+        instance: &'a VirtualizedApp,
+        store: &mut wasmtime::Store<T>,
+        fields: Fields,
+    ) -> anyhow::Result<Self> {
+        let guest = instance.wasi_http_types().outgoing_request();
+        let resource = guest.call_constructor(store, fields.resource)?;
+        Ok(Self { guest, resource })
+    }
+
+    pub fn set_path_with_query<T>(
+        &self,
+        store: &mut wasmtime::Store<T>,
+        path: Option<&str>,
+    ) -> anyhow::Result<Result<(), ()>> {
+        self.guest
+            .call_set_path_with_query(store, self.resource, path)
+    }
+}
+
+struct IncomingRequest<'a> {
+    #[allow(dead_code)]
+    guest: bindings::exports::wasi::http::types::GuestIncomingRequest<'a>,
+    resource: wasmtime::component::ResourceAny,
+}
+
+impl<'a> IncomingRequest<'a> {
+    fn new<T>(
+        instance: &'a VirtualizedApp,
+        store: &mut wasmtime::Store<T>,
+        outgoing_request: OutgoingRequest,
+    ) -> anyhow::Result<Self> {
+        let guest = instance.fermyon_spin_wasi_virt_http_helper();
+        let resource = guest.call_new_request(store, outgoing_request.resource, None)?;
+        let guest = instance.wasi_http_types().incoming_request();
+        Ok(Self { guest, resource })
+    }
+}
+
+fn new_response<'a, T>(
+    instance: &'a VirtualizedApp,
+    store: &mut wasmtime::Store<T>,
+) -> anyhow::Result<(wasmtime::component::ResourceAny, ResponseReceiver<'a>)> {
+    let guest = instance.fermyon_spin_wasi_virt_http_helper();
+    let (out_param, rx) = guest.call_new_response(store)?;
+    let rx_guest = instance
+        .fermyon_spin_wasi_virt_http_helper()
+        .response_receiver();
+
+    Ok((
+        out_param,
+        ResponseReceiver {
+            instance,
+            resource: rx,
+            guest: rx_guest,
+        },
+    ))
+}
+
+struct ResponseReceiver<'a> {
+    instance: &'a VirtualizedApp,
+    guest: bindings::exports::fermyon::spin_wasi_virt::http_helper::GuestResponseReceiver<'a>,
+    resource: wasmtime::component::ResourceAny,
+}
+
+impl<'a> ResponseReceiver<'a> {
+    fn get<T>(
+        &self,
+        store: &mut wasmtime::Store<T>,
+    ) -> anyhow::Result<Option<IncomingResponse<'a>>> {
+        let Some(resource) = self.guest.call_get(store, self.resource)? else {
+            return Ok(None);
+        };
+        Ok(Some(IncomingResponse {
+            instance: self.instance,
+            guest: self.instance.wasi_http_types().incoming_response(),
+            resource,
+        }))
+    }
+}
+
+struct IncomingResponse<'a> {
+    instance: &'a VirtualizedApp,
+    guest: bindings::exports::wasi::http::types::GuestIncomingResponse<'a>,
+    resource: wasmtime::component::ResourceAny,
+}
+
+impl<'a> IncomingResponse<'a> {
+    fn status<T>(&self, store: &mut wasmtime::Store<T>) -> anyhow::Result<u16> {
+        self.guest.call_status(store, self.resource)
+    }
+
+    fn headers<T>(&self, store: &mut wasmtime::Store<T>) -> anyhow::Result<Fields> {
+        let fields = self.guest.call_headers(store, self.resource)?;
+        Ok(Fields {
+            guest: self.instance.wasi_http_types().fields(),
+            resource: fields,
+        })
+    }
+
+    fn consume<T>(
+        &self,
+        store: &mut wasmtime::Store<T>,
+    ) -> wasmtime::Result<Result<IncomingBody<'a>, ()>> {
+        let Ok(resource) = self.guest.call_consume(store, self.resource)? else {
+            return Ok(Err(()));
+        };
+        let guest = self.instance.wasi_http_types().incoming_body();
+        Ok(Ok(IncomingBody {
+            instance: self.instance,
+            guest,
+            resource,
+        }))
+    }
+}
+
+struct IncomingBody<'a> {
+    instance: &'a VirtualizedApp,
+    guest: bindings::exports::wasi::http::types::GuestIncomingBody<'a>,
+    resource: wasmtime::component::ResourceAny,
+}
+
+impl<'a> IncomingBody<'a> {
+    fn stream<T>(
+        &self,
+        store: &mut wasmtime::Store<T>,
+    ) -> wasmtime::Result<Result<InputStream, ()>> {
+        let Ok(resource) = self.guest.call_stream(store, self.resource)? else {
+            return Ok(Err(()));
+        };
+        Ok(Ok(InputStream {
+            instance: self.instance,
+            resource,
+        }))
+    }
+}
+
+struct InputStream<'a> {
+    instance: &'a VirtualizedApp,
+    resource: wasmtime::component::ResourceAny,
+}
+
+impl<'a> InputStream<'a> {
+    fn blocking_read<T>(
+        &self,
+        store: &mut wasmtime::Store<T>,
+        max_bytes: u64,
+    ) -> wasmtime::Result<Result<Vec<u8>, bindings::exports::wasi::io::streams::StreamError>> {
+        self.instance
+            .wasi_io_streams()
+            .input_stream()
+            .call_blocking_read(store, self.resource, max_bytes)
+    }
+}
+
+struct StoreData {
+    manifest: String,
+    ctx: wasmtime_wasi::WasiCtx,
+    table: wasmtime::component::ResourceTable,
+}
+
+impl StoreData {
+    fn new(manifest: String) -> Self {
+        let ctx = wasmtime_wasi::WasiCtxBuilder::new().inherit_stdio().build();
+        let table = wasmtime::component::ResourceTable::default();
+        Self {
+            manifest,
+            ctx,
+            table,
+        }
+    }
+}
+
+impl wasmtime_wasi::WasiView for StoreData {
+    fn table(&mut self) -> &mut wasmtime_wasi::ResourceTable {
+        &mut self.table
+    }
+
+    fn ctx(&mut self) -> &mut wasmtime_wasi::WasiCtx {
+        &mut self.ctx
+    }
+}
+
+impl bindings::VirtualizedAppImports for StoreData {
+    fn get_manifest(&mut self) -> String {
+        self.manifest.clone()
+    }
+}

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = { workspace = true }
-wit-bindgen-rt = "0.25.0"
+wit-bindgen-rt = "0.26.0"
 toml = { workspace = true }
 spin-manifest = { workspace = true }
 spin-http = { git = "https://github.com/fermyon/spin", default-features = false }

--- a/crates/spin-test-virt/src/wasi/http.rs
+++ b/crates/spin-test-virt/src/wasi/http.rs
@@ -44,7 +44,7 @@ pub struct IncomingRequest {
     pub body: Consumable<IncomingBody>,
 }
 
-/// A `Result` type where `Err` is the consumed value.
+/// A value which keeps track of whether it's been "consumed" or not.
 #[derive(Clone, Debug)]
 pub struct Consumable<T> {
     value: T,
@@ -64,6 +64,12 @@ impl<T> Consumable<T> {
             value: f(self.value),
             consumed: self.consumed,
         }
+    }
+}
+
+impl<T> AsRef<T> for Consumable<T> {
+    fn as_ref(&self) -> &T {
+        &self.value
     }
 }
 
@@ -246,6 +252,12 @@ impl exports::types::GuestIncomingResponse for IncomingResponse {
 #[derive(Clone, Debug)]
 pub struct OutgoingBody(io::Buffer);
 
+impl OutgoingBody {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
 impl exports::types::GuestOutgoingBody for OutgoingBody {
     fn write(&self) -> Result<io::exports::streams::OutputStream, ()> {
         Ok(io::exports::streams::OutputStream::new(
@@ -304,6 +316,12 @@ where
 #[derive(Debug, Default, Clone)]
 pub struct Fields {
     fields: RefCell<HashMap<exports::types::FieldKey, Vec<exports::types::FieldValue>>>,
+}
+
+impl Fields {
+    pub fn insert(&self, key: exports::types::FieldKey, value: exports::types::FieldValue) {
+        self.fields.borrow_mut().entry(key).or_default().push(value);
+    }
 }
 
 impl exports::types::GuestFields for Fields {

--- a/crates/spin-test-virt/src/wasi/http_helper.rs
+++ b/crates/spin-test-virt/src/wasi/http_helper.rs
@@ -65,10 +65,15 @@ impl exports::GuestResponseReceiver for ResponseReceiver {
         let response = match &*self.0.lock().unwrap() {
             Some(Ok(r)) => {
                 let outgoing = r.get::<OutgoingResponse>();
+                let body = outgoing.body.unconsume();
+                let content_length = body.as_ref().len();
+                outgoing
+                    .headers
+                    .insert("Content-Length".into(), content_length.to_string().into());
                 Some(IncomingResponse {
                     status: outgoing.status_code.get(),
                     headers: outgoing.headers.clone(),
-                    body: outgoing.body.unconsume().map(Into::into),
+                    body: body.map(Into::into),
                 })
             }
             Some(Err(e)) => {

--- a/host-wit/world.wit
+++ b/host-wit/world.wit
@@ -25,6 +25,18 @@ world dynamic-runner {
     export fermyon:spin-wasi-virt/fs-handler;
 }
 
+world virtualized-app {
+    import get-manifest: func() -> string;
+    
+    export wasi:clocks/monotonic-clock@0.2.0;
+    export wasi:io/streams@0.2.0;
+    export wasi:io/error@0.2.0;
+    export wasi:io/poll@0.2.0;
+    export wasi:http/types@0.2.0;
+    export wasi:http/incoming-handler@0.2.0;
+    export fermyon:spin-wasi-virt/http-helper;
+}
+
 /// A test runner that can run a `spin-test` test composition
 world runner {
     /// Include all dynamic runner items

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,7 @@ impl Virtualize {
             .context("failed to read app component")?;
         let encoded =
             spin_test::virtualize_app(app_component).context("failed to virtualize app")?;
-        std::fs::write("virtualized.wasm", &encoded)
+        std::fs::write("virtualized.wasm", encoded)
             .context("failed to write virtualized app to disk")?;
         println!("Successfully virtualized app to virtualized.wasm");
         Ok(())


### PR DESCRIPTION
This PR consumes the test from https://github.com/fermyon/conformance-tests and runs Spin test against it. This ensures that `spin-test` has the same observable behavior as other Spin runtimes that are run against these conformance tests (for now this is just Spin CLI, but it will grow to other runtimes in the future).

This does not yet run in CI, but I'd like to do that relatively soon in a follow up PR. 