### PR TITLE
Update to conformance test for key-value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 [[package]]
 name = "conformance-tests"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests#8549e0fa0cb7ed41263335cb895eb509c1b61a49"
+source = "git+https://github.com/fermyon/conformance-tests#cfee7a519b59f4318d5a19358ec3f2bf1bc23f41"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2530,7 +2530,7 @@ dependencies = [
 [[package]]
 name = "test-environment"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests#8549e0fa0cb7ed41263335cb895eb509c1b61a49"
+source = "git+https://github.com/fermyon/conformance-tests#cfee7a519b59f4318d5a19358ec3f2bf1bc23f41"
 dependencies = [
  "anyhow",
  "fslock",

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -156,8 +156,10 @@ fn calculate_default_headers(
     base: &str,
     route_match: &RouteMatch,
 ) -> anyhow::Result<Vec<([String; 2], String)>> {
+    fn convert(s: &str) -> String {
+        s.to_owned().replace('_', "-").to_ascii_lowercase()
+    }
     fn owned(strs: &[&'static str; 2]) -> [String; 2] {
-        let convert = |s: &str| s.to_owned().replace('_', "-").to_ascii_lowercase();
         [convert(strs[0]), convert(strs[1])]
     }
 
@@ -205,8 +207,11 @@ fn calculate_default_headers(
     res.push((owned_client_addr, "127.0.0.1:0".to_owned()));
 
     for (wild_name, wild_value) in route_match.named_wildcards() {
-        let wild_header = format!("SPIN_PATH_MATCH_{}", wild_name.to_ascii_uppercase());
-        let wild_wagi_header = format!("X_PATH_MATCH_{}", wild_name.to_ascii_uppercase());
+        let wild_header = convert(&format!(
+            "SPIN_PATH_MATCH_{}",
+            wild_name.to_ascii_uppercase()
+        ));
+        let wild_wagi_header = convert(&format!("X_PATH_MATCH_{}", wild_name.to_ascii_uppercase()));
         res.push(([wild_header, wild_wagi_header], wild_value.clone()));
     }
 


### PR DESCRIPTION
Updating to the latest conformance test.

Fixed a bug to get the conformance tests to pass where by the `x-path-match-*` headers were the wrong case and did not handle `_` to `-` conversions.