### PR TITLE
Update conformance tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,11 +363,12 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 [[package]]
 name = "conformance-tests"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests#cfee7a519b59f4318d5a19358ec3f2bf1bc23f41"
+source = "git+https://github.com/fermyon/conformance-tests?branch=tcp-test#0b6de095f37026ebb4ba75ed31f6ec509904d2c7"
 dependencies = [
  "anyhow",
  "flate2",
  "json5",
+ "libtest-mimic",
  "reqwest",
  "serde",
  "tar",
@@ -2530,7 +2531,7 @@ dependencies = [
 [[package]]
 name = "test-environment"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests#cfee7a519b59f4318d5a19358ec3f2bf1bc23f41"
+source = "git+https://github.com/fermyon/conformance-tests?branch=tcp-test#0b6de095f37026ebb4ba75ed31f6ec509904d2c7"
 dependencies = [
  "anyhow",
  "fslock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 [[package]]
 name = "conformance-tests"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests?branch=tcp-test#0b6de095f37026ebb4ba75ed31f6ec509904d2c7"
+source = "git+https://github.com/fermyon/conformance-tests?branch=main#4eb7a94fbd1b640babd89e729df380ef4cd84fe6"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2367,6 +2367,7 @@ name = "spin-test-virt"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ipnet",
  "spin-expressions",
  "spin-manifest",
  "spin-outbound-networking",
@@ -2531,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "test-environment"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests?branch=tcp-test#0b6de095f37026ebb4ba75ed31f6ec509904d2c7"
+source = "git+https://github.com/fermyon/conformance-tests?branch=main#4eb7a94fbd1b640babd89e729df380ef4cd84fe6"
 dependencies = [
  "anyhow",
  "fslock",

--- a/conformance-tests/Cargo.toml
+++ b/conformance-tests/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-conformance-tests = { git = "https://github.com/fermyon/conformance-tests", branch = "tcp-test" }
-test-environment = { git = "https://github.com/fermyon/conformance-tests", branch = "tcp-test" }
+conformance-tests = { git = "https://github.com/fermyon/conformance-tests", branch = "main" }
+test-environment = { git = "https://github.com/fermyon/conformance-tests", branch = "main" }
 spin-test = { path = ".." }
 wasmtime = "21.0"
 wasmtime-wasi = "21.0"

--- a/conformance-tests/Cargo.toml
+++ b/conformance-tests/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-conformance-tests = { git = "https://github.com/fermyon/conformance-tests" }
-test-environment = { git = "https://github.com/fermyon/conformance-tests" }
+conformance-tests = { git = "https://github.com/fermyon/conformance-tests", branch = "tcp-test" }
+test-environment = { git = "https://github.com/fermyon/conformance-tests", branch = "tcp-test" }
 spin-test = { path = ".." }
 wasmtime = "21.0"
 wasmtime-wasi = "21.0"

--- a/conformance-tests/src/main.rs
+++ b/conformance-tests/src/main.rs
@@ -39,6 +39,7 @@ fn run_test(test: conformance_tests::Test) -> Result<(), anyhow::Error> {
         invocation.request.substitute(|key, value| {
             Ok(match (key, value) {
                 ("port", "80") => Some(HTTP_PORT.to_string()),
+                ("port", "5000") => Some(5000.to_string()),
                 _ => None,
             })
         })?;

--- a/crates/spin-test-virt/Cargo.toml
+++ b/crates/spin-test-virt/Cargo.toml
@@ -5,12 +5,13 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-wit-bindgen-rt = { version = "0.25.0", features = ["bitflags"] }
+ipnet = "2.9"
 spin-expressions = { workspace = true }
 spin-manifest = { workspace = true }
 spin-outbound-networking = { workspace = true }
 spin-serde = { workspace = true }
 toml = { workspace = true }
+wit-bindgen-rt = { version = "0.25.0", features = ["bitflags"] }
 
 
 [lib]

--- a/crates/spin-test-virt/src/wasi.rs
+++ b/crates/spin-test-virt/src/wasi.rs
@@ -5,6 +5,7 @@ mod filesystem;
 pub mod http;
 pub mod http_helper;
 pub mod io;
+mod tcp;
 
 use crate::bindings::exports::wasi;
 use crate::Component;
@@ -152,9 +153,17 @@ impl wasi::cli::exit::Guest for Component {
 
 impl wasi::sockets::instance_network::Guest for Component {
     fn instance_network() -> wasi::sockets::instance_network::Network {
-        todo!()
+        wasi::sockets::instance_network::Network::new(Network)
     }
 }
+
+impl wasi::sockets::network::Guest for Component {
+    type Network = Network;
+}
+
+pub struct Network;
+
+impl wasi::sockets::network::GuestNetwork for Network {}
 
 impl wasi::sockets::ip_name_lookup::Guest for Component {
     type ResolveAddressStream = ResolveAddressStream;
@@ -183,187 +192,6 @@ impl wasi::sockets::ip_name_lookup::GuestResolveAddressStream for ResolveAddress
     }
 
     fn subscribe(&self) -> wasi::sockets::ip_name_lookup::Pollable {
-        todo!()
-    }
-}
-
-impl wasi::sockets::network::Guest for Component {
-    type Network = Network;
-}
-
-pub struct Network;
-
-impl wasi::sockets::network::GuestNetwork for Network {}
-
-impl wasi::sockets::tcp::Guest for Component {
-    type TcpSocket = TcpSocket;
-}
-
-pub struct TcpSocket;
-
-impl wasi::sockets::tcp::GuestTcpSocket for TcpSocket {
-    fn start_bind(
-        &self,
-        network: wasi::sockets::tcp::NetworkBorrow<'_>,
-        local_address: wasi::sockets::tcp::IpSocketAddress,
-    ) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn finish_bind(&self) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn start_connect(
-        &self,
-        network: wasi::sockets::tcp::NetworkBorrow<'_>,
-        remote_address: wasi::sockets::tcp::IpSocketAddress,
-    ) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn finish_connect(
-        &self,
-    ) -> Result<
-        (
-            wasi::sockets::tcp::InputStream,
-            wasi::sockets::tcp::OutputStream,
-        ),
-        wasi::sockets::tcp::ErrorCode,
-    > {
-        todo!()
-    }
-
-    fn start_listen(&self) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn finish_listen(&self) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn accept(
-        &self,
-    ) -> Result<
-        (
-            wasi::sockets::tcp::TcpSocket,
-            wasi::sockets::tcp::InputStream,
-            wasi::sockets::tcp::OutputStream,
-        ),
-        wasi::sockets::tcp::ErrorCode,
-    > {
-        todo!()
-    }
-
-    fn local_address(
-        &self,
-    ) -> Result<wasi::sockets::tcp::IpSocketAddress, wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn remote_address(
-        &self,
-    ) -> Result<wasi::sockets::tcp::IpSocketAddress, wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn is_listening(&self) -> bool {
-        todo!()
-    }
-
-    fn address_family(&self) -> wasi::sockets::tcp::IpAddressFamily {
-        todo!()
-    }
-
-    fn set_listen_backlog_size(&self, value: u64) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn keep_alive_enabled(&self) -> Result<bool, wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn set_keep_alive_enabled(&self, value: bool) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn keep_alive_idle_time(
-        &self,
-    ) -> Result<wasi::sockets::tcp::Duration, wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn set_keep_alive_idle_time(
-        &self,
-        value: wasi::sockets::tcp::Duration,
-    ) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn keep_alive_interval(
-        &self,
-    ) -> Result<wasi::sockets::tcp::Duration, wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn set_keep_alive_interval(
-        &self,
-        value: wasi::sockets::tcp::Duration,
-    ) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn keep_alive_count(&self) -> Result<u32, wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn set_keep_alive_count(&self, value: u32) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn hop_limit(&self) -> Result<u8, wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn set_hop_limit(&self, value: u8) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn receive_buffer_size(&self) -> Result<u64, wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn set_receive_buffer_size(&self, value: u64) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn send_buffer_size(&self) -> Result<u64, wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn set_send_buffer_size(&self, value: u64) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-
-    fn subscribe(&self) -> wasi::sockets::tcp::Pollable {
-        todo!()
-    }
-
-    fn shutdown(
-        &self,
-        shutdown_type: wasi::sockets::tcp::ShutdownType,
-    ) -> Result<(), wasi::sockets::tcp::ErrorCode> {
-        todo!()
-    }
-}
-
-impl wasi::sockets::tcp_create_socket::Guest for Component {
-    fn create_tcp_socket(
-        address_family: wasi::sockets::tcp_create_socket::IpAddressFamily,
-    ) -> Result<
-        wasi::sockets::tcp_create_socket::TcpSocket,
-        wasi::sockets::tcp_create_socket::ErrorCode,
-    > {
         todo!()
     }
 }

--- a/crates/spin-test-virt/src/wasi/tcp.rs
+++ b/crates/spin-test-virt/src/wasi/tcp.rs
@@ -1,0 +1,181 @@
+use crate::bindings::exports::wasi;
+use crate::Component;
+
+use super::io::{Buffer, InputStream, OutputStream};
+
+impl wasi::sockets::tcp_create_socket::Guest for Component {
+    fn create_tcp_socket(
+        address_family: wasi::sockets::tcp_create_socket::IpAddressFamily,
+    ) -> Result<
+        wasi::sockets::tcp_create_socket::TcpSocket,
+        wasi::sockets::tcp_create_socket::ErrorCode,
+    > {
+        Ok(wasi::sockets::tcp_create_socket::TcpSocket::new(TcpSocket))
+    }
+}
+
+impl wasi::sockets::tcp::Guest for Component {
+    type TcpSocket = TcpSocket;
+}
+
+pub struct TcpSocket;
+
+impl wasi::sockets::tcp::GuestTcpSocket for TcpSocket {
+    fn start_bind(
+        &self,
+        network: wasi::sockets::tcp::NetworkBorrow<'_>,
+        local_address: wasi::sockets::tcp::IpSocketAddress,
+    ) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn finish_bind(&self) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn start_connect(
+        &self,
+        network: wasi::sockets::tcp::NetworkBorrow<'_>,
+        remote_address: wasi::sockets::tcp::IpSocketAddress,
+    ) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        Ok(())
+    }
+
+    fn finish_connect(
+        &self,
+    ) -> Result<
+        (
+            wasi::sockets::tcp::InputStream,
+            wasi::sockets::tcp::OutputStream,
+        ),
+        wasi::sockets::tcp::ErrorCode,
+    > {
+        let shared = Buffer::empty();
+        Ok((
+            wasi::sockets::tcp::InputStream::new(InputStream::Buffered(shared.clone())),
+            wasi::sockets::tcp::OutputStream::new(OutputStream::Buffered(shared)),
+        ))
+    }
+
+    fn start_listen(&self) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn finish_listen(&self) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn accept(
+        &self,
+    ) -> Result<
+        (
+            wasi::sockets::tcp::TcpSocket,
+            wasi::sockets::tcp::InputStream,
+            wasi::sockets::tcp::OutputStream,
+        ),
+        wasi::sockets::tcp::ErrorCode,
+    > {
+        todo!()
+    }
+
+    fn local_address(
+        &self,
+    ) -> Result<wasi::sockets::tcp::IpSocketAddress, wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn remote_address(
+        &self,
+    ) -> Result<wasi::sockets::tcp::IpSocketAddress, wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn is_listening(&self) -> bool {
+        todo!()
+    }
+
+    fn address_family(&self) -> wasi::sockets::tcp::IpAddressFamily {
+        todo!()
+    }
+
+    fn set_listen_backlog_size(&self, value: u64) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn keep_alive_enabled(&self) -> Result<bool, wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn set_keep_alive_enabled(&self, value: bool) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn keep_alive_idle_time(
+        &self,
+    ) -> Result<wasi::sockets::tcp::Duration, wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn set_keep_alive_idle_time(
+        &self,
+        value: wasi::sockets::tcp::Duration,
+    ) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn keep_alive_interval(
+        &self,
+    ) -> Result<wasi::sockets::tcp::Duration, wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn set_keep_alive_interval(
+        &self,
+        value: wasi::sockets::tcp::Duration,
+    ) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn keep_alive_count(&self) -> Result<u32, wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn set_keep_alive_count(&self, value: u32) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn hop_limit(&self) -> Result<u8, wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn set_hop_limit(&self, value: u8) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn receive_buffer_size(&self) -> Result<u64, wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn set_receive_buffer_size(&self, value: u64) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn send_buffer_size(&self) -> Result<u64, wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn set_send_buffer_size(&self, value: u64) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+
+    fn subscribe(&self) -> wasi::sockets::tcp::Pollable {
+        todo!()
+    }
+
+    fn shutdown(
+        &self,
+        shutdown_type: wasi::sockets::tcp::ShutdownType,
+    ) -> Result<(), wasi::sockets::tcp::ErrorCode> {
+        todo!()
+    }
+}


### PR DESCRIPTION
With 100% more TCP!

One of the TCP tests still fails because we're not properly handling variables in the `allowed_outbound_hosts`. I can fix that in a follow up. 