### PR TITLE
Embed sqlite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.76
+  WASI_SDK_VERSION: "22.0"
+  WASI_SDK_RELEASE: wasi-sdk-22
+
 jobs:
   lint-rust:
     name: Lint Rust
@@ -39,6 +42,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
+      - name: Install WASI-SDK
+        shell: bash
+        run: |
+          cd /tmp
+          curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/${WASI_SDK_RELEASE}/wasi-sdk-${WASI_SDK_VERSION}-linux.tar.gz
+          tar xf wasi-sdk-${WASI_SDK_VERSION}-linux.tar.gz
+          echo "WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_SDK_VERSION}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
 
@@ -52,10 +62,12 @@ jobs:
 
   build-rust:
     name: Build Plugin
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        config: 
+          - { os: ubuntu-latest, platform: "linux" }
+          - { os: macos-latest, platform: "macos" }
     steps:
       # install dependencies
       - name: Install latest Rust stable toolchain
@@ -71,6 +83,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
+      - name: Install WASI-SDK
+        shell: bash
+        run: |
+          cd /tmp
+          curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/${WASI_SDK_RELEASE}/wasi-sdk-${WASI_SDK_VERSION}-${{ matrix.config.platform }}.tar.gz
+          tar xf wasi-sdk-${WASI_SDK_VERSION}-${{ matrix.config.platform }}.tar.gz
+          echo "WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_SDK_VERSION}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
 
@@ -96,6 +115,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
+      - name: Install WASI-SDK
+        shell: bash
+        run: |
+          cd /tmp
+          curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/${WASI_SDK_RELEASE}/wasi-sdk-${WASI_SDK_VERSION}-linux.tar.gz
+          tar xf wasi-sdk-${WASI_SDK_VERSION}-linux.tar.gz
+          echo "WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_SDK_VERSION}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
       - name: Cargo Unit Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,15 +64,6 @@ jobs:
               target: "aarch64-apple-darwin",
               targetDir: "target/aarch64-apple-darwin/release/",
             }
-          - {
-              os: "windows-latest",
-              arch: "amd64",
-              wasiSDK: "",
-              extension: ".exe",
-              buildArgs: "",
-              target: "",
-              targetDir: "target/release",
-            }
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain
@@ -93,6 +84,15 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-component
+
+      - name: Install WASI-SDK
+        shell: bash
+        run: |
+          cd /tmp
+          curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/${WASI_SDK_RELEASE}/wasi-sdk-${WASI_SDK_VERSION}-${{ matrix.config.wasiSDK }}.tar.gz
+          tar xf wasi-sdk-${WASI_SDK_VERSION}-${{ matrix.config.wasiSDK }}.tar.gz
+          mv wasi-sdk-${WASI_SDK_VERSION} ${{ matrix.config.targetDir }}/wasi-sdk
+          echo "WASI_SDK_PATH=${{ matrix.config.targetDir}}/wasi-sdk" >> $GITHUB_ENV
 
       - name: set the release version (main)
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+## Building from source
+
+To build `spin-test` from source, you'll need to [download the `WASI_SDK`](https://github.com/WebAssembly/wasi-sdk/releases/) (needed for the C compiler used to compile some C dependencies). Once you have the SDK on your machine somewhere, point to it via the `WASI_SDK_PATH` environment variable.
+
+You can then run `cargo build --release` to build `spin-test`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,7 +374,7 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 [[package]]
 name = "conformance-tests"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests?branch=sqlite#04aac58de41d6b0ebd5bd99b8fccf6854ad690cc"
+source = "git+https://github.com/fermyon/conformance-tests?branch=main#6e30479fda142cbe49763cba888e20c13383123f"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2601,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "test-environment"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests?branch=sqlite#04aac58de41d6b0ebd5bd99b8fccf6854ad690cc"
+source = "git+https://github.com/fermyon/conformance-tests?branch=main#6e30479fda142cbe49763cba888e20c13383123f"
 dependencies = [
  "anyhow",
  "fslock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,17 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -363,7 +374,7 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 [[package]]
 name = "conformance-tests"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests?branch=main#4eb7a94fbd1b640babd89e729df380ef4cd84fe6"
+source = "git+https://github.com/fermyon/conformance-tests?branch=sqlite#04aac58de41d6b0ebd5bd99b8fccf6854ad690cc"
 dependencies = [
  "anyhow",
  "flate2",
@@ -700,9 +711,21 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -938,7 +961,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "indexmap 2.2.6",
  "stable_deref_trait",
 ]
@@ -970,6 +993,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.8",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -980,7 +1012,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -989,8 +1021,17 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "serde",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
+dependencies = [
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1334,6 +1375,17 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1908,6 +1960,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4b1eaf239b47034fb450ee9cdedd7d0226571689d8823030c4b6c2cb407152"
+dependencies = [
+ "bitflags 1.3.2",
+ "fallible-iterator 0.2.0",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,6 +2436,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ipnet",
+ "rusqlite",
  "spin-expressions",
  "spin-manifest",
  "spin-outbound-networking",
@@ -2533,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "test-environment"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests?branch=main#4eb7a94fbd1b640babd89e729df380ef4cd84fe6"
+source = "git+https://github.com/fermyon/conformance-tests?branch=sqlite#04aac58de41d6b0ebd5bd99b8fccf6854ad690cc"
 dependencies = [
  "anyhow",
  "fslock",
@@ -3124,7 +3192,7 @@ version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "bitflags 2.5.0",
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
@@ -3138,7 +3206,7 @@ version = "0.211.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3189cc8a91f547390e2f043ca3b3e3fe0892f7d581767fd4e4b7f3dc3fe8e561"
 dependencies = [
- "ahash",
+ "ahash 0.8.11",
  "bitflags 2.5.0",
  "hashbrown 0.14.5",
  "indexmap 2.2.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,7 +1904,7 @@ dependencies = [
  "spin-http",
  "spin-manifest",
  "toml",
- "wit-bindgen-rt 0.26.0",
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -2348,7 +2348,7 @@ name = "spin-test-sdk"
 version = "0.1.0"
 dependencies = [
  "spin-test-sdk-macro",
- "wit-bindgen 0.25.0",
+ "wit-bindgen 0.26.0",
 ]
 
 [[package]]
@@ -2374,7 +2374,7 @@ dependencies = [
  "spin-outbound-networking",
  "spin-serde",
  "toml",
- "wit-bindgen-rt 0.25.0",
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -2971,15 +2971,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.208.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6425e84e42f7f558478e40ecc2287912cb319f2ca68e5c0bb93c61d4fc63fa17"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4a05336882dae732ce6bd48b7e11fe597293cb72c13da4f35d7d5f8d53b2a7"
@@ -3047,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.208.1"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a2c4280ad374a6db3d76d4bb61e2ec4b3b9ce5469cc4f2bbc5708047a2bbff"
+checksum = "4d32029ce424f6d3c2b39b4419fb45a0e2d84fb0751e0c0a32b7ce8bd5d97f46"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3057,8 +3048,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.208.1",
- "wasmparser 0.208.1",
+ "wasm-encoder 0.209.1",
+ "wasmparser 0.209.1",
 ]
 
 [[package]]
@@ -3123,19 +3114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6998515d3cf3f8b980ef7c11b29a9b1017d4cf86b99ae93b546992df9931413"
 dependencies = [
  "bitflags 2.5.0",
- "indexmap 2.2.6",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.208.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd921789c9dcc495f589cb37d200155dee65b4a4beeb853323b5e24e0a5f9c58"
-dependencies = [
- "ahash",
- "bitflags 2.5.0",
- "hashbrown 0.14.5",
  "indexmap 2.2.6",
  "semver",
 ]
@@ -3781,12 +3759,12 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f497a5ce965e6cb9929079bb4af633bd88dfb19d0dfc5341580e354947f00b2"
+checksum = "a84376ff4f74ed07674a1157c0bd19e6627ab01fc90952a27ccefb52a24530f0"
 dependencies = [
- "wit-bindgen-rt 0.25.0",
- "wit-bindgen-rust-macro 0.25.0",
+ "wit-bindgen-rt",
+ "wit-bindgen-rust-macro 0.26.0",
 ]
 
 [[package]]
@@ -3802,22 +3780,13 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7076a12e69af6e1f6093bd16657d7ae61c30cfd3c5f62321046eb863b17ab1e2"
+checksum = "36d4706efb67fadfbbde77955b299b111dd096e6776d8c6561d92f6147941880"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.208.1",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef83e2f948056d4195b4c2a236a10378b70c8fd7501039c5a106c1a756fa7da6"
-dependencies = [
- "bitflags 2.5.0",
+ "wit-parser 0.209.1",
 ]
 
 [[package]]
@@ -3825,6 +3794,9 @@ name = "wit-bindgen-rt"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c7526379ace8709ee9ab9f2bb50f112d95581063a59ef3097d9c10153886c9"
+dependencies = [
+ "bitflags 2.5.0",
+]
 
 [[package]]
 name = "wit-bindgen-rust"
@@ -3841,16 +3813,16 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8ca0dd2aa75452450da1906391aba9d3a43d95fa920e872361ea00acc452a5"
+checksum = "514295193d1a2f42e6a948cd7d9fd81e2b8fadc319667dcf19fd7aceaf2113a2"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.2.6",
- "wasm-metadata 0.208.1",
- "wit-bindgen-core 0.25.0",
- "wit-component 0.208.1",
+ "wasm-metadata 0.209.1",
+ "wit-bindgen-core 0.26.0",
+ "wit-component 0.209.1",
 ]
 
 [[package]]
@@ -3870,16 +3842,16 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d734e18bdf439ed86afe9d85fc5bfa38db4b676fc0e0a0dae95bd8f14de039"
+checksum = "f0409a3356ca02599aff78f717968fd7f12df4bf879f325e2a97b45c84c90fff"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.63",
- "wit-bindgen-core 0.25.0",
- "wit-bindgen-rust 0.25.0",
+ "wit-bindgen-core 0.26.0",
+ "wit-bindgen-rust 0.26.0",
 ]
 
 [[package]]
@@ -3922,9 +3894,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.208.1"
+version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef7dd0e47f5135dd8739ccc5b188ab8b7e27e1d64df668aa36680f0b8646db8"
+checksum = "25a2bb5b039f9cb03425e1d5a6e54b441ca4ca1b1d4fa6a0924db67a55168f99"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
@@ -3933,10 +3905,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.208.1",
- "wasm-metadata 0.208.1",
- "wasmparser 0.208.1",
- "wit-parser 0.208.1",
+ "wasm-encoder 0.209.1",
+ "wasm-metadata 0.209.1",
+ "wasmparser 0.209.1",
+ "wit-parser 0.209.1",
 ]
 
 [[package]]
@@ -3991,24 +3963,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.200.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.208.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516417a730725fe3e6c9e2efc8d86697480f80496d32b24e62736950704c047c"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.2.6",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.208.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,5 +41,6 @@ spin-manifest = { git = "https://github.com/fermyon/spin" }
 spin-outbound-networking = { git = "https://github.com/fermyon/spin" }
 spin-serde = { git = "https://github.com/fermyon/spin" }
 toml = { version = "0.8", features = ["preserve_order"] }
+wit-bindgen-rt = { version = "0.26", features = ["bitflags"] }
 wit-component = "0.211"
 wit-parser = "0.211"

--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ spin test
 ## Examples
 
 See the [`examples`](./examples/) directory for a few examples of `spin-test` tests that test the apps in the [`apps`](./examples/apps/) directory.
+
+## Building from source and contributing
+
+See the [guide on contributing for more information](./CONTRIBUTING.md).

--- a/build.rs
+++ b/build.rs
@@ -37,6 +37,8 @@ fn ensure_wasi_sdk() -> Vec<(&'static str, String)> {
     vec![
         ("WASI_SDK_PATH", wasi_sdk_path_string),
         ("CC_wasm32_wasi", clang_path_string),
+        ("LIBSQLITE3_FLAGS", "-DSQLITE_OS_OTHER -USQLITE_TEMP_STORE -DSQLITE_TEMP_STORE=3 -USQLITE_THREADSAFE 
+        -DSQLITE_THREADSAFE=0 -DSQLITE_OMIT_LOCALTIME -DSQLITE_OMIT_LOAD_EXTENSION -DLONGDOUBLE_TYPE=double".to_string()),
     ]
 }
 

--- a/build.rs
+++ b/build.rs
@@ -2,18 +2,61 @@ use std::{env, process};
 
 fn main() {
     check_cargo_component_installed();
-    cargo_component_build("crates/router");
-    cargo_component_build("crates/spin-test-virt");
+    cargo_component_build(
+        "crates/router",
+        Target::Wasm32UnknownUnknown,
+        std::iter::empty(),
+    );
+    let wasi_env = ensure_wasi_sdk();
+    cargo_component_build(
+        "crates/spin-test-virt",
+        Target::Wasm32Wasi,
+        wasi_env.iter().map(|(k, v)| (*k, v.as_str())),
+    );
+}
+
+fn ensure_wasi_sdk() -> Vec<(&'static str, String)> {
+    let Ok(wasi_sdk_path_string) = std::env::var("WASI_SDK_PATH") else {
+        panic!("WASI_SDK_PATH env variable is not set.");
+    };
+    let wasi_sdk_path = &std::path::Path::new(&wasi_sdk_path_string);
+    if !wasi_sdk_path.exists() {
+        panic!(
+            "WASI_SDK_PATH is set to a non-existent path: {}",
+            wasi_sdk_path.display()
+        );
+    }
+    let clang_path_string = format!("{}/{}", wasi_sdk_path_string, "bin/clang");
+    let clang_path = std::path::Path::new(&clang_path_string);
+    if !clang_path.exists() {
+        panic!(
+            "WASI_SDK_PATH is set to a path that does not contain clang: {}",
+            clang_path.display()
+        );
+    }
+    vec![
+        ("WASI_SDK_PATH", wasi_sdk_path_string),
+        ("CC_wasm32_wasi", clang_path_string),
+    ]
 }
 
 fn check_cargo_component_installed() {
-    let (_, output) = run(["cargo", "component", "--version"], ".");
+    let (_, output) = run(["cargo", "component", "--version"], ".", std::iter::empty());
     if !output.status.success() {
         panic!("cargo-component is not installed. Please install it by running `cargo install cargo-component`");
     }
 }
 
-fn cargo_component_build(dir: &str) {
+enum Target {
+    Wasm32UnknownUnknown,
+    Wasm32Wasi,
+}
+
+fn cargo_component_build<'a>(
+    dir: &str,
+    target: Target,
+    env: impl Iterator<Item = (&'a str, &'a str)>,
+) {
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let (cmd, output) = run(
         [
@@ -21,12 +64,16 @@ fn cargo_component_build(dir: &str) {
             "component",
             "build",
             "--target",
-            "wasm32-unknown-unknown",
+            match target {
+                Target::Wasm32UnknownUnknown => "wasm32-unknown-unknown",
+                Target::Wasm32Wasi => "wasm32-wasi",
+            },
             "--release",
             "--target-dir",
             out_dir.to_str().unwrap(),
         ],
         dir,
+        env,
     );
     if !output.status.success() {
         println!("{}", std::str::from_utf8(&output.stderr).unwrap());
@@ -37,13 +84,18 @@ fn cargo_component_build(dir: &str) {
     println!("cargo:rerun-if-changed={dir}/src");
 }
 
-fn run<'a>(args: impl IntoIterator<Item = &'a str> + 'a, dir: &str) -> (String, process::Output) {
+fn run<'a, 'b>(
+    args: impl IntoIterator<Item = &'a str> + 'a,
+    dir: &str,
+    env: impl Iterator<Item = (&'b str, &'b str)>,
+) -> (String, process::Output) {
     let mut cmd = process::Command::new(get_os_process());
     cmd.stdout(process::Stdio::inherit());
     cmd.stderr(process::Stdio::piped());
     cmd.current_dir(dir);
 
     cmd.arg("-c");
+    cmd.envs(env);
     let c = args
         .into_iter()
         .map(Into::into)

--- a/conformance-tests/Cargo.toml
+++ b/conformance-tests/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-conformance-tests = { git = "https://github.com/fermyon/conformance-tests", branch = "main" }
-test-environment = { git = "https://github.com/fermyon/conformance-tests", branch = "main" }
+conformance-tests = { git = "https://github.com/fermyon/conformance-tests", branch = "sqlite" }
+test-environment = { git = "https://github.com/fermyon/conformance-tests", branch = "sqlite" }
 spin-test = { path = ".." }
 wasmtime = "22.0"
 wasmtime-wasi = "22.0"

--- a/conformance-tests/Cargo.toml
+++ b/conformance-tests/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-conformance-tests = { git = "https://github.com/fermyon/conformance-tests", branch = "sqlite" }
-test-environment = { git = "https://github.com/fermyon/conformance-tests", branch = "sqlite" }
+conformance-tests = { git = "https://github.com/fermyon/conformance-tests", branch = "main" }
+test-environment = { git = "https://github.com/fermyon/conformance-tests", branch = "main" }
 spin-test = { path = ".." }
 wasmtime = "22.0"
 wasmtime-wasi = "22.0"

--- a/conformance-tests/src/main.rs
+++ b/conformance-tests/src/main.rs
@@ -7,7 +7,7 @@ use runtime::SpinTest;
 const HTTP_PORT: u16 = 1234;
 
 fn main() -> anyhow::Result<()> {
-    conformance_tests::run_tests(run_test)
+    conformance_tests::run_tests_from("../../conformance-tests/conformance-tests", run_test)
 }
 
 fn run_test(test: conformance_tests::Test) -> Result<(), anyhow::Error> {
@@ -29,6 +29,7 @@ fn run_test(test: conformance_tests::Test) -> Result<(), anyhow::Error> {
             }
             conformance_tests::config::Precondition::TcpEcho => {}
             conformance_tests::config::Precondition::KeyValueStore(_) => {}
+            conformance_tests::config::Precondition::Sqlite => {}
         }
     }
     for invocation in test.config.invocations {

--- a/conformance-tests/src/main.rs
+++ b/conformance-tests/src/main.rs
@@ -7,7 +7,7 @@ use runtime::SpinTest;
 const HTTP_PORT: u16 = 1234;
 
 fn main() -> anyhow::Result<()> {
-    conformance_tests::run_tests_from("../../conformance-tests/conformance-tests", run_test)
+    conformance_tests::run_tests(run_test)
 }
 
 fn run_test(test: conformance_tests::Test) -> Result<(), anyhow::Error> {
@@ -47,9 +47,9 @@ fn run_test(test: conformance_tests::Test) -> Result<(), anyhow::Error> {
 /// When encountering a magic key-value pair, substitute the value with a different value.
 fn substitution(key: &str, value: &str) -> Option<String> {
     match (key, value) {
+        ("port", "7") => Some(7.to_string()),
         ("port", "80") => Some(HTTP_PORT.to_string()),
-        ("port", "5000") => Some(5000.to_string()),
-        _ => None,
+        _ => panic!("Unexpected substitution: {} = {}", key, value),
     }
 }
 

--- a/conformance-tests/src/runtime.rs
+++ b/conformance-tests/src/runtime.rs
@@ -32,7 +32,10 @@ pub(crate) struct SpinTest {
 
 impl SpinTest {
     pub fn new(manifest: String, component_path: PathBuf) -> anyhow::Result<Self> {
-        let engine = wasmtime::Engine::default();
+        let mut engine_config = wasmtime::Config::new();
+        engine_config.cache_config_load_default()?;
+        let engine = wasmtime::Engine::new(&engine_config)?;
+
         let mut store = wasmtime::Store::new(&engine, super::StoreData::new(manifest));
         let mut linker = wasmtime::component::Linker::new(&engine);
         let component = spin_test::Component::from_file(component_path)?;
@@ -46,6 +49,7 @@ impl SpinTest {
 
         Ok(Self { instance, store })
     }
+
     /// Make an HTTP request against the `spin-test` runtime
     pub fn make_http_request(
         &mut self,

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = { workspace = true }
-wit-bindgen-rt = "0.26.0"
-toml = { workspace = true }
-spin-manifest = { workspace = true }
 spin-http = { git = "https://github.com/fermyon/spin", default-features = false }
+spin-manifest = { workspace = true }
+toml = { workspace = true }
+wit-bindgen-rt = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/spin-test-sdk/Cargo.toml
+++ b/crates/spin-test-sdk/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 spin-test-sdk-macro = { path = "../spin-test-sdk-macro" }
-wit-bindgen = "0.25"
+wit-bindgen = "0.26"

--- a/crates/spin-test-virt/Cargo.toml
+++ b/crates/spin-test-virt/Cargo.toml
@@ -11,7 +11,7 @@ spin-manifest = { workspace = true }
 spin-outbound-networking = { workspace = true }
 spin-serde = { workspace = true }
 toml = { workspace = true }
-wit-bindgen-rt = { version = "0.25.0", features = ["bitflags"] }
+wit-bindgen-rt = { workspace = true }
 
 
 [lib]

--- a/crates/spin-test-virt/Cargo.toml
+++ b/crates/spin-test-virt/Cargo.toml
@@ -12,6 +12,7 @@ spin-outbound-networking = { workspace = true }
 spin-serde = { workspace = true }
 toml = { workspace = true }
 wit-bindgen-rt = { workspace = true }
+rusqlite = { version = "0.25", features = ["bundled", "wasm32-wasi-vfs"] }
 
 
 [lib]

--- a/crates/spin-test-virt/Cargo.toml
+++ b/crates/spin-test-virt/Cargo.toml
@@ -12,6 +12,7 @@ spin-outbound-networking = { workspace = true }
 spin-serde = { workspace = true }
 toml = { workspace = true }
 wit-bindgen-rt = { workspace = true }
+# rusqlite > 0.25 fails to build with various linker errors
 rusqlite = { version = "0.25", features = ["bundled", "wasm32-wasi-vfs"] }
 
 

--- a/crates/spin-test-virt/src/lib.rs
+++ b/crates/spin-test-virt/src/lib.rs
@@ -430,7 +430,7 @@ impl SqliteConnection {
         let rows = prepared
             .query_map(rusqlite::params_from_iter(params), |row| {
                 let mut values = Vec::new();
-                for i in 0..row.column_count() {
+                for i in 0..result.columns.len() {
                     let v = match row.get(i)? {
                         rusqlite::types::Value::Null => sqlite::Value::Null,
                         rusqlite::types::Value::Integer(i) => sqlite::Value::Integer(i),

--- a/host-wit/deps/spin-test-virt/world.wit
+++ b/host-wit/deps/spin-test-virt/world.wit
@@ -26,9 +26,18 @@ world env {
 /// Interface for configuring the behavior of `fermyon:spin/sqlite` interface
 interface sqlite {
     use fermyon:spin/sqlite@2.0.0.{value, query-result, error};
+  
+    resource connection {
+      /// Open a connection to a named database instance.
+      ///
+      /// If `database` is "default", the default instance is opened.
+      ///
+      /// `error::no-such-database` will be raised if the `name` is not recognized.
+      open: static func(database: string) -> result<connection, error>;
 
-    /// Set a response for a given query and set of params
-    set-response: func(query: string, params: list<value>, response: result<query-result, error>);
+      /// Execute a statement returning back data if there is any
+      execute: func(statement: string, parameters: list<value>) -> result<query-result, error>;
+    }
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub use manifest::ManifestInformation;
 /// The built `spin-test-virt` component
 const SPIN_TEST_VIRT: &[u8] = include_bytes!(concat!(
     env!("OUT_DIR"),
-    "/wasm32-unknown-unknown/release/spin_test_virt.wasm"
+    "/wasm32-wasi/release/spin_test_virt.wasm"
 ));
 /// The built `router` component
 const ROUTER: &[u8] = include_bytes!(concat!(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -33,7 +33,9 @@ impl Runtime {
         if std::env::var("SPIN_TEST_DUMP_COMPOSITION").is_ok() {
             let _ = std::fs::write("composition.wasm", composed_component);
         }
-        let engine = wasmtime::Engine::default();
+        let mut engine_config = wasmtime::Config::new();
+        engine_config.cache_config_load_default()?;
+        let engine = wasmtime::Engine::new(&engine_config)?;
         let store = wasmtime::Store::new(&engine, Data::new(manifest.raw().to_owned()));
 
         let component = wasmtime::component::Component::new(&engine, composed_component)


### PR DESCRIPTION
Attempts to address https://github.com/fermyon/conformance-tests/pull/18

This embeds sqlite into `spin-test-virt` making it possible for tests to directly interact with the sqlite database before and after the tested app is invoked. 

There are some downsides to this:
* `spin-test-virt` becomes much bigger which slows everything down (mainly due to compilation of the wasm taking much more time). 
* Building `spin-test` now requires a `wasi-sdk` and the `WASK_SDK_PATH` env variable to be set which can make contributing more of a chore. 