### PR TITLE
Correctly implement new-request.

### DIFF
--- a/crates/spin-test-virt/src/wasi/http.rs
+++ b/crates/spin-test-virt/src/wasi/http.rs
@@ -164,7 +164,7 @@ pub struct OutgoingRequest {
     pub authority: RefCell<Option<String>>,
     pub path_with_query: RefCell<Option<String>>,
     pub headers: Fields,
-    body: Consumable<OutgoingBody>,
+    pub body: Consumable<OutgoingBody>,
 }
 
 impl exports::types::GuestOutgoingRequest for OutgoingRequest {
@@ -259,6 +259,12 @@ impl OutgoingBody {
     }
 }
 
+impl From<IncomingBody> for OutgoingBody {
+    fn from(i: IncomingBody) -> Self {
+        Self(i.0)
+    }
+}
+
 impl exports::types::GuestOutgoingBody for OutgoingBody {
     fn write(&self) -> Result<io::exports::streams::OutputStream, ()> {
         Ok(io::exports::streams::OutputStream::new(
@@ -274,7 +280,7 @@ impl exports::types::GuestOutgoingBody for OutgoingBody {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct IncomingBody(io::Buffer);
 
 impl IncomingBody {

--- a/crates/spin-test-virt/src/wasi/http_helper.rs
+++ b/crates/spin-test-virt/src/wasi/http_helper.rs
@@ -34,7 +34,10 @@ impl exports::Guest for Component {
             authority,
             path_with_query,
             headers,
-            body: body.unwrap_or_else(IncomingBody::empty).into(),
+            // Either override the body with `incoming_body`, or use the body from the original request
+            body: body
+                .map(Into::into)
+                .unwrap_or_else(|| request.body.unconsume().map(Into::into)),
         })
     }
 


### PR DESCRIPTION
Fixes #106 

Previously, if the `incoming-body` override was `none` we set the body to empty instead of defaulting to the existing body in `request`.

This meant that we were always setting the body to empty when the user used the `spin-test` Rust SDK.