### PR TITLE
fix: pin version of cargo component

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_COMPONENT_VERSION: 0.13.2
   RUST_VERSION: 1.76
   WASI_SDK_VERSION: "22.0"
   WASI_SDK_RELEASE: wasi-sdk-22
@@ -39,6 +40,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-component
+          version: ${{ env.CARGO_COMPONENT_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
@@ -80,6 +82,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-component
+          version: ${{ env.CARGO_COMPONENT_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
@@ -112,6 +115,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-component
+          version: ${{ env.CARGO_COMPONENT_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"


### PR DESCRIPTION
The latest version of cargo component (v0.14) swaps the wasi target to the new format. https://github.com/bytecodealliance/cargo-component/pull/313

This seemed the most minimal way to get CI to run again, but I'll also do another branch that updates everything else if that is also desirable.
