### PR TITLE
Updates for latest cargo-component version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.76
+  CARGO_COMPONENT_VERSION: 0.14.0
+  RUST_VERSION: 1.79
   WASI_SDK_VERSION: "22.0"
   WASI_SDK_RELEASE: wasi-sdk-22
 
@@ -34,11 +35,12 @@ jobs:
           rustup toolchain install ${{ env.RUST_VERSION }} --component clippy --component rustfmt
           rustup default ${{ env.RUST_VERSION }}
       - name: Install Wasm Rust target
-        run: rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
+        run: rustup target add wasm32-wasip1 && rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
       - name: Install cargo-component
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-component
+          version: ${{ env.CARGO_COMPONENT_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
@@ -53,19 +55,17 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cargo Format
-        run:
-          cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Cargo Clippy
-        run:
-          cargo clippy --workspace --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   build-rust:
     name: Build Plugin
     runs-on: ${{ matrix.config.os }}
     strategy:
       matrix:
-        config: 
+        config:
           - { os: ubuntu-latest, platform: "linux" }
           - { os: macos-latest, platform: "macos" }
     steps:
@@ -75,11 +75,12 @@ jobs:
           rustup toolchain install ${{ env.RUST_VERSION }} --component clippy --component rustfmt --no-self-update
           rustup default ${{ env.RUST_VERSION }}
       - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
+        run: rustup target add wasm32-wasip1 && rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
       - name: Install cargo-component
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-component
+          version: ${{ env.CARGO_COMPONENT_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"
@@ -107,11 +108,12 @@ jobs:
           rustup toolchain install ${{ env.RUST_VERSION }} --component clippy --component rustfmt --no-self-update
           rustup default ${{ env.RUST_VERSION }}
       - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
+        run: rustup target add wasm32-wasip1 && rustup target add wasm32-wasi && rustup target add wasm32-unknown-unknown
       - name: Install cargo-component
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-component
+          version: ${{ env.CARGO_COMPONENT_VERSION }}
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock') }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ concurrency: ${{ github.workflow }}
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.76
+  CARGO_COMPONENT_VERSION: 0.14.0
+  RUST_VERSION: 1.79
   WASI_SDK_VERSION: "22.0"
   WASI_SDK_RELEASE: wasi-sdk-22
 
@@ -40,14 +41,14 @@ jobs:
               targetDir: "target/release",
             }
           - {
-            os: "ubuntu-20.04",
-            arch: "aarch64",
-            wasiSDK: "linux",
-            extension: "",
-            buildArgs: "--target aarch64-unknown-linux-gnu",
-            target: "aarch64-unknown-linux-gnu",
-            targetDir: "target/aarch64-unknown-linux-gnu/release",
-          }
+              os: "ubuntu-20.04",
+              arch: "aarch64",
+              wasiSDK: "linux",
+              extension: "",
+              buildArgs: "--target aarch64-unknown-linux-gnu",
+              target: "aarch64-unknown-linux-gnu",
+              targetDir: "target/aarch64-unknown-linux-gnu/release",
+            }
           - {
               os: "macos-latest",
               arch: "amd64",
@@ -80,12 +81,13 @@ jobs:
         run: rustup target add --toolchain ${{ env.RUST_VERSION }} ${{ matrix.config.target }}
 
       - name: "Install Wasm Rust target"
-        run: rustup target add wasm32-wasi --toolchain ${{ env.RUST_VERSION }} && rustup target add wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
+        run: rustup target add wasm32-wasip1 --toolchain ${{ env.RUST_VERSION }} && rustup target add wasm32-wasi --toolchain ${{ env.RUST_VERSION }} && rustup target add wasm32-unknown-unknown --toolchain ${{ env.RUST_VERSION }}
 
       - name: Install cargo-component
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-component
+          version: ${{ env.CARGO_COMPONENT_VERSION }}
 
       - name: Install WASI-SDK
         shell: bash
@@ -135,8 +137,8 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-            name: spin-test-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}
-            path: _dist/spin-test-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+          name: spin-test-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}
+          path: _dist/spin-test-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
 
       - name: upload binary to Github release
         if: startsWith(github.ref, 'refs/tags/v')
@@ -219,7 +221,7 @@ jobs:
           pattern: spin-test-*
           merge-multiple: true
 
-      - name: 'Check if canary tag exists'
+      - name: "Check if canary tag exists"
         id: canaryExists
         shell: bash
         run: |


### PR DESCRIPTION
v0.14.0 of cargo-component requires the `wasm32-wasip1` target, which is only available in Rust versions 1.78.0 and later.

This updates the `RUST_VERSION`, the target name, as well as pins the `CARGO_COMPONENT_VERSION` to hopefully avoid an issue like this in the future.
