### PR TITLE
Respect the exclude files option in the spin toml manifest

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -88,7 +88,6 @@ impl Runtime {
 
     /// Make all mounted files visible to the WASI virtual filesystem
     fn add_files(&mut self, runner: dynamic::DynamicRunner) -> anyhow::Result<()> {
-        //TODO(rylev): handle component.exclude_files
         /// Make a file visible to the WASI virtual filesystem
         fn add_file<T>(
             store: &mut wasmtime::Store<T>,
@@ -116,6 +115,15 @@ impl Runtime {
 
                         // Host path is the absolute path to the file
                         let host_path = self.manifest.absolute_from(host_path);
+                        // If the file among list of files to be excluded, skip it
+                        if self
+                            .manifest
+                            .component()
+                            .exclude_files
+                            .contains(&host_path.display().to_string())
+                        {
+                            continue;
+                        }
                         // Only add files
                         if !host_path.is_file() {
                             continue;
@@ -140,6 +148,15 @@ impl Runtime {
                             .unwrap_or(destination.as_str())
                     );
                     let host_path = self.manifest.absolute_from(source);
+                    // If the file among list of files to be excluded, skip it
+                    if self
+                        .manifest
+                        .component()
+                        .exclude_files
+                        .contains(&host_path.display().to_string())
+                    {
+                        continue;
+                    }
 
                     // If the host path is a directory, add all files in the directory
                     if host_path.is_dir() {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -113,8 +113,6 @@ impl Runtime {
                             format!("failed to read glob entry for pattern '{p}'")
                         })?;
 
-                        // Host path is the absolute path to the file
-                        let host_path = self.manifest.absolute_from(host_path);
                         // If the file among list of files to be excluded, skip it
                         if self
                             .manifest
@@ -124,6 +122,10 @@ impl Runtime {
                         {
                             continue;
                         }
+
+                        // Host path is the absolute path to the file
+                        let host_path = self.manifest.absolute_from(host_path);
+
                         // Only add files
                         if !host_path.is_file() {
                             continue;
@@ -147,16 +149,13 @@ impl Runtime {
                             .strip_prefix('/')
                             .unwrap_or(destination.as_str())
                     );
-                    let host_path = self.manifest.absolute_from(source);
+
                     // If the file among list of files to be excluded, skip it
-                    if self
-                        .manifest
-                        .component()
-                        .exclude_files
-                        .contains(&host_path.display().to_string())
-                    {
+                    if self.manifest.component().exclude_files.contains(source) {
                         continue;
                     }
+
+                    let host_path = self.manifest.absolute_from(source);
 
                     // If the host path is a directory, add all files in the directory
                     if host_path.is_dir() {


### PR DESCRIPTION
Aims to fix #79 

checks if `host_path` is the path of the app manifest's component `exclude_files`